### PR TITLE
Temporary fix for mnras float error

### DIFF
--- a/showyourwork.yml
+++ b/showyourwork.yml
@@ -1,11 +1,10 @@
-version: 0.3.1
+version: 0.3.1.post1
 
 overleaf:
-  id: 6347f3e2b7602e1c0ca344ff
+  id: #6347f3e2b7602e1c0ca344ff
   push:
     - src/tex/figures
     - src/tex/output
   pull:
     - src/tex/ms.tex
     - src/tex/bib.bib
-

--- a/showyourwork.yml
+++ b/showyourwork.yml
@@ -1,7 +1,7 @@
 version: 0.3.1.post1
 
 overleaf:
-  id: #6347f3e2b7602e1c0ca344ff
+  id: 6347f3e2b7602e1c0ca344ff
   push:
     - src/tex/figures
     - src/tex/output

--- a/src/tex/ms.tex
+++ b/src/tex/ms.tex
@@ -19,6 +19,21 @@
 \usepackage{threeparttablex}
 \usepackage{array}
 
+% --- HACK to remove showyourwork abstract margin icon
+\makeatletter
+\def\abstract{\if@twocolumn
+   \start@SFBbox\@abstract
+ \else
+   \@abstract
+ \fi}
+\def\endabstract{\if@twocolumn
+   \endlist\finish@SFBbox
+ \else
+  \endlist
+ \fi}
+\makeatother
+% ---
+
 %\usepackage{pdflscape}
 
 %%%%% AUTHORS - PLACE YOUR OWN MACROS HERE %%%%%


### PR DESCRIPTION
This PR removes the abstract margin icon placed by `showyourwork`, which was causing a `Float(s) lost` error. I don't fully understand what the issue was, so I'll keep thinking of a proper way to fix it.

This PR also upgrades to `0.3.1.post1` to fix an issue with `Snakemake` that was breaking all builds.