### PR TITLE
Path fix for static figure

### DIFF
--- a/src/tex/ms.tex
+++ b/src/tex/ms.tex
@@ -306,7 +306,7 @@ Galaxy: structure --- Galaxy: evolution --- Galaxy: kinematics and dynamics --- 
 
 \begin{figure}
     \begin{centering}
-        \includegraphics[width=\linewidth]{static/279e12_merger_ratio_gas.pdf}
+        \includegraphics[width=\linewidth]{figures/279e12_merger_ratio_gas.pdf}
         \caption{
             
         }


### PR DESCRIPTION
Static figures are placed in the `src/tex/figures` directory along with the other programmatically-generated figures (not `src/tex/static`).